### PR TITLE
Update date gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,6 @@ group :development do
   gem "brakeman", require: false
   gem "fasterer", require: false
 end
+
+# https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/
+gem "date", ">= 3.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -264,6 +265,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   brakeman
   bundler-audit
+  date (>= 3.2.1)
   dotenv-rails
   fasterer
   license_finder


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/