### PR TITLE
Revert "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,11 +102,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)


### PR DESCRIPTION
Reverts evemonk/evemonk-pg-extras#356